### PR TITLE
'float' object cannot be interpreted as an integer

### DIFF
--- a/excelcy/excelcy.py
+++ b/excelcy/excelcy.py
@@ -234,7 +234,7 @@ class ExcelCy(object):
         # train now
         nlp.vocab.vectors.name = 'spacy_pretrained_vectors'
         optimizer = nlp.begin_training()
-        for itn in range(self.storage.config.train_iteration):
+        for itn in range(int(self.storage.config.train_iteration)):
             random.shuffle(train_idx)
             for idx in train_idx:
                 text = self.storage.train.items[idx].text


### PR DESCRIPTION
I've downloaded `test_data_01.xlsx` from Google Sheet, and faced this bug.
```
    for itn in range(self.storage.config.train_iteration):
TypeError: 'float' object cannot be interpreted as an integer
```
I'm not sure why exactly this bug happens, but I fixed it by converting `self.storage.config.train_iteration` to int